### PR TITLE
Fix: Operation not set in PunchOutSetupRequest

### DIFF
--- a/src/CXml/Models/Requests/PunchOutSetupRequest.php
+++ b/src/CXml/Models/Requests/PunchOutSetupRequest.php
@@ -16,7 +16,7 @@ class PunchOutSetupRequest implements RequestInterface
     /** @noinspection PhpUndefinedFieldInspection */
     public function parse(\SimpleXMLElement $requestNode): void
     {
-        $this->buyerCookie = (string)$requestNode->attributes()->operation;
+        $this->operation = (string)$requestNode->attributes()->operation;
         $this->buyerCookie = $requestNode->xpath('BuyerCookie')[0];
         $this->browserFormPostUrl = $requestNode->xpath('BrowserFormPost/URL')[0];
     }


### PR DESCRIPTION
Wrong property name is used in the parser.